### PR TITLE
feat: add bitwise operators support

### DIFF
--- a/pngencoder.lua
+++ b/pngencoder.lua
@@ -3,6 +3,39 @@ Png.__index = Png
 
 local DEFLATE_MAX_BLOCK_SIZE = 65535
 
+if bit32 then -- lua5.2, luajit compatiable, luajit has bit, lua5.2 has bit32
+  bit = bit32
+elseif not bit then
+  -- lua5.3+ use bitwise operator
+  bit = load(
+  [[
+    local function to32bit(n)
+      return n & 0xFFFFFFFF
+    end
+    local t = {
+    band = function(a, b)
+      return to32bit(a & b)
+    end,
+    bor = function(a, b)
+      return to32bit(a | b)
+    end,
+    bxor = function(a, b)
+      return to32bit(a ~ b)
+    end,
+    bnot = function(a)
+      return to32bit(~a)
+    end,
+    lshift = function(a, b)
+      return to32bit(a << b)
+    end,
+    rshift = function(a, b)
+      return to32bit(a >> b)
+    end,
+    }
+    return t
+  ]])()
+end
+
 local function putBigUint32(val, tbl, index)
     for i=0,3 do
         tbl[index + i] = bit.band(bit.rshift(val, (3 - i) * 8), 0xFF)

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,42 @@
+local begin = require("pngencoder")
+
+local function writebuf(buf, w, h, fname)
+  -- write to png
+  local png = begin(w, h)
+  for i = 1, w * h do
+    local v = buf[i]
+    if not v then
+      png:write({ 0, 0, 0 })
+    else
+      png:write({ math.floor(v[1] + 0.5), math.floor(v[2] + 0.5), math.floor(v[3] + 0.5) })
+    end
+  end
+
+  assert(png.done)
+  local pngbin = table.concat(png.output)
+  local file = assert(io.open(fname, "wb"))
+  file:write(pngbin)
+  file:close()
+end
+
+-- test passed on luajit, lua5.2, lua5.3, lua5.4, macOS14.6
+local function test()
+  local w, h = 128, 128
+  local buf = {}
+  local n = 8
+  for i = 1, w do
+    for j = 1, h do
+      local color = { 0xFF, 0xFF, 0xFF }
+      local u, v = i / (w + 1), j / (h + 1)
+      local d = math.floor(u * n) + math.floor(v * n)
+      if d % 2 == 0 then
+        color[1], color[2], color[3] = 0x40, 0x40, 0x40
+      end
+      buf[(h - i) * w + j] = color
+    end
+  end
+
+  writebuf(buf, w, h, "testpng.png")
+end
+
+test()


### PR DESCRIPTION
I have added bitwise operators support, and tested in multi versions. Now users can use pngencoder directly without concerning  bit library.